### PR TITLE
Remove real credentials from docs

### DIFF
--- a/SISTEMA_FUNCIONANDO_RELATORIO.md
+++ b/SISTEMA_FUNCIONANDO_RELATORIO.md
@@ -20,7 +20,7 @@
 Credenciais:
 - UF: RN
 - CRM: 7546
-- Senha: @Luassis90
+- Senha: password123
 
 Token gerado: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 Status: ✅ FUNCIONANDO
@@ -133,7 +133,7 @@ Status: ✅ FUNCIONANDO
 
 ### **SISTEMA 100% FUNCIONAL E OPERACIONAL**
 
-1. **✅ Login funcionando** com credenciais RN/7546/@Luassis90
+1. **✅ Login funcionando** com credenciais RN/7546/password123
 2. **✅ Backend respondendo** corretamente em todas as rotas
 3. **✅ Frontend renderizando** com layout premium
 4. **✅ Componentes corrigidos** e props compatíveis

--- a/VERCEL_DEPLOY_STATUS.md
+++ b/VERCEL_DEPLOY_STATUS.md
@@ -49,7 +49,7 @@ frontend/src/pages/
 
 ### **Como Testar**
 
-1. **Acesse o sistema** com suas credenciais (RN, 7546, @Luassis90)
+1. **Acesse o sistema** com suas credenciais (RN, 7546, password123)
 2. **Verifique layout único** - UserMenu deve aparecer apenas no header top-right
 3. **Navegue entre páginas** - layout consistente e espaçamento adequado
 4. **Teste dark mode** - footer e layout otimizados

--- a/VERCEL_QUICK_SETUP.md
+++ b/VERCEL_QUICK_SETUP.md
@@ -44,7 +44,7 @@ VITE_ENABLE_ERROR_REPORTING=true
 
 ### 4. Teste
 
-- Login: UF=RN, CRM=6091, senha=@Luassis90
+- Login: UF=RN, CRM=6091, senha=password123
 - Verifique se API calls funcionam
 
 ## ✅ Checklist Rápido

--- a/VERCEL_SETUP_GUIDE.md
+++ b/VERCEL_SETUP_GUIDE.md
@@ -93,7 +93,7 @@ Após o deploy, teste:
 
 1. **Frontend**: https://medcheck-app.vercel.app
 2. **Health Check via Vercel**: https://medcheck-app.vercel.app/health
-3. **Login**: Use as credenciais UF=RN, CRM=6091, senha=@Luassis90
+3. **Login**: Use as credenciais UF=RN, CRM=6091, senha=password123
 
 ## 🔧 Configurações Avançadas
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ async def async_client(test_db) -> AsyncGenerator[AsyncClient, None]:
 @pytest.fixture(scope="function")
 def sample_user_data():
     """Dados de usuário para testes."""
-    return {"uf": "RN", "crm": "6091", "password": "@Luassis90"}
+    return {"uf": "RN", "crm": "6091", "password": "password123"}
 
 
 @pytest.fixture(scope="function")

--- a/tests/e2e/test_user_flows.py
+++ b/tests/e2e/test_user_flows.py
@@ -21,7 +21,7 @@ class TestAuthenticationFlow:
         # Act - Fazer login
         page.fill('input[name="uf"]', "RN")
         page.fill('input[name="crm"]', "6091")
-        page.fill('input[name="password"]', "@Luassis90")
+        page.fill('input[name="password"]', "password123")
         page.click('button[type="submit"]')
 
         # Assert - Verificar redirecionamento para dashboard
@@ -75,7 +75,7 @@ class TestAuthenticationFlow:
         page.goto("http://localhost:3000")
         page.fill('input[name="uf"]', "RN")
         page.fill('input[name="crm"]', "6091")
-        page.fill('input[name="password"]', "@Luassis90")
+        page.fill('input[name="password"]', "password123")
         page.click('button[type="submit"]')
         expect(page).to_have_url("http://localhost:3000/dashboard")
 
@@ -145,7 +145,7 @@ class TestDashboardFlow:
         page.goto("http://localhost:3000")
         page.fill('input[name="uf"]', "RN")
         page.fill('input[name="crm"]', "6091")
-        page.fill('input[name="password"]', "@Luassis90")
+        page.fill('input[name="password"]', "password123")
         page.click('button[type="submit"]')
         expect(page).to_have_url("http://localhost:3000/dashboard")
 
@@ -240,7 +240,7 @@ class TestGuiasUploadFlow:
         page.goto("http://localhost:3000")
         page.fill('input[name="uf"]', "RN")
         page.fill('input[name="crm"]', "6091")
-        page.fill('input[name="password"]', "@Luassis90")
+        page.fill('input[name="password"]', "password123")
         page.click('button[type="submit"]')
         expect(page).to_have_url("http://localhost:3000/dashboard")
 
@@ -306,7 +306,7 @@ class TestDemonstrativosFlow:
         page.goto("http://localhost:3000")
         page.fill('input[name="uf"]', "RN")
         page.fill('input[name="crm"]', "6091")
-        page.fill('input[name="password"]', "@Luassis90")
+        page.fill('input[name="password"]', "password123")
         page.click('button[type="submit"]')
         expect(page).to_have_url("http://localhost:3000/dashboard")
 
@@ -371,7 +371,7 @@ class TestAccessibilityAndUsability:
         page.goto("http://localhost:3000")
         page.fill('input[name="uf"]', "RN")
         page.fill('input[name="crm"]', "6091")
-        page.fill('input[name="password"]', "@Luassis90")
+        page.fill('input[name="password"]', "password123")
         page.click('button[type="submit"]')
         expect(page).to_have_url("http://localhost:3000/dashboard")
 
@@ -440,6 +440,6 @@ class TestPerformanceAndReliability:
         page.goto("http://localhost:3000")
         page.fill('input[name="uf"]', "RN")
         page.fill('input[name="crm"]', "6091")
-        page.fill('input[name="password"]', "@Luassis90")
+        page.fill('input[name="password"]', "password123")
         page.click('button[type="submit"]')
         expect(page).to_have_url("http://localhost:3000/dashboard")

--- a/tests/performance/load-test.js
+++ b/tests/performance/load-test.js
@@ -34,7 +34,7 @@ const BASE_URL = __ENV.BASE_URL || "http://localhost:8000";
 const TEST_USER = {
   uf: "RN",
   crm: "6091",
-  password: "@Luassis90",
+  password: "password123",
 };
 
 /**

--- a/verify-production-readiness.py
+++ b/verify-production-readiness.py
@@ -33,7 +33,7 @@ import requests
 # Configurações
 BACKEND_URL = "http://localhost:8000"
 FRONTEND_URL = "http://localhost:8080"
-TEST_USER = {"uf": "RN", "crm": "6091", "password": "@Luassis90"}
+TEST_USER = {"uf": "RN", "crm": "6091", "password": "password123"}
 
 
 class Colors:


### PR DESCRIPTION
## Summary
- scrub real password from documentation and test scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*
- `npm test --silent` in `frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e67a90a00832c81213585fff3c415